### PR TITLE
Added health setting object to common file outputs

### DIFF
--- a/lib/classes/file/base-file.ts
+++ b/lib/classes/file/base-file.ts
@@ -1,7 +1,7 @@
 import { camelCase } from 'lodash';
 import * as comments from 'parse-comments';
 
-import { Property, Comment } from '../../models/';
+import { Property, Comment, Health } from '../../models/';
 import { MenuItem } from '../menu-item';
 import { CommonMetaProperties } from './common-meta';
 
@@ -26,12 +26,16 @@ export class BaseFile {
     const title: string = regex.exec(this.filePath)[0].replace('.', '');
     const properties: Property[] = undefined;
     const id: string = camelCase(title);
+    const health: Health = {
+      missingDescription: description.length === 0,
+    };
     
     this.common = {
       description,
       title,
       properties,
       id,
+      health,
     };
   }
   

--- a/lib/classes/file/base-meta.ts
+++ b/lib/classes/file/base-meta.ts
@@ -1,4 +1,4 @@
-import { Property } from '../../models';
+import { Property, Health } from '../../models';
 import { CommonMetaProperties } from './common-meta';
 
 export class BaseMeta implements CommonMetaProperties {
@@ -6,11 +6,13 @@ export class BaseMeta implements CommonMetaProperties {
   title: string;
   description: string;
   properties: Property[];
+  health: Health;
 
   constructor(common: CommonMetaProperties) {
     this.id = common.id;
     this.title = common.title;
     this.properties = common.properties;
     this.description = common.description;
+    this.health = common.health;
   }
 }

--- a/lib/classes/file/common-meta.ts
+++ b/lib/classes/file/common-meta.ts
@@ -1,8 +1,9 @@
-import { Property } from '../../models/Property';
+import { Property, Health } from '../../models/';
 
 export interface CommonMetaProperties {
   id: string;
   title: string;
   properties: Property[];
   description: string;
+  health: Health;
 }

--- a/lib/classes/file/meta/model-meta.ts
+++ b/lib/classes/file/meta/model-meta.ts
@@ -4,5 +4,6 @@ export class ModelMeta extends BaseMeta {
 
   constructor(common) {
     super(common);
+    this.health.missingProperties = this.properties.length === 0;
   }
 }

--- a/lib/models/health.ts
+++ b/lib/models/health.ts
@@ -1,0 +1,4 @@
+export interface Health {
+  missingDescription: boolean;
+  missingProperties?: boolean;
+}

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -1,3 +1,4 @@
 export * from './property';
 export * from './options';
 export * from './comment';
+export * from './health';

--- a/out/lib/classes/file/base-file.js
+++ b/out/lib/classes/file/base-file.js
@@ -17,11 +17,15 @@ var BaseFile = /** @class */ (function () {
         var title = regex.exec(this.filePath)[0].replace('.', '');
         var properties = undefined;
         var id = lodash_1.camelCase(title);
+        var health = {
+            missingDescription: description.length === 0
+        };
         this.common = {
             description: description,
             title: title,
             properties: properties,
-            id: id
+            id: id,
+            health: health
         };
     };
     BaseFile.prototype.getDescription = function (comments) {

--- a/out/lib/classes/file/base-meta.d.ts
+++ b/out/lib/classes/file/base-meta.d.ts
@@ -1,9 +1,10 @@
-import { Property } from '../../models';
+import { Property, Health } from '../../models';
 import { CommonMetaProperties } from './common-meta';
 export declare class BaseMeta implements CommonMetaProperties {
     id: string;
     title: string;
     description: string;
     properties: Property[];
+    health: Health;
     constructor(common: CommonMetaProperties);
 }

--- a/out/lib/classes/file/base-meta.js
+++ b/out/lib/classes/file/base-meta.js
@@ -6,6 +6,7 @@ var BaseMeta = /** @class */ (function () {
         this.title = common.title;
         this.properties = common.properties;
         this.description = common.description;
+        this.health = common.health;
     }
     return BaseMeta;
 }());

--- a/out/lib/classes/file/common-meta.d.ts
+++ b/out/lib/classes/file/common-meta.d.ts
@@ -1,7 +1,8 @@
-import { Property } from '../../models/Property';
+import { Property, Health } from '../../models/';
 export interface CommonMetaProperties {
     id: string;
     title: string;
     properties: Property[];
     description: string;
+    health: Health;
 }

--- a/out/lib/classes/file/meta/model-meta.js
+++ b/out/lib/classes/file/meta/model-meta.js
@@ -14,7 +14,9 @@ var base_meta_1 = require("../base-meta");
 var ModelMeta = /** @class */ (function (_super) {
     __extends(ModelMeta, _super);
     function ModelMeta(common) {
-        return _super.call(this, common) || this;
+        var _this = _super.call(this, common) || this;
+        _this.health.missingProperties = _this.properties.length === 0;
+        return _this;
     }
     return ModelMeta;
 }(base_meta_1.BaseMeta));

--- a/out/lib/classes/folder-scan.d.ts
+++ b/out/lib/classes/folder-scan.d.ts
@@ -1,6 +1,6 @@
 import { BaseFile, FolderMeta, MenuItem } from '../classes';
 import { SourceOption } from '../models';
-import { PipeFile } from './file';
+import { ServiceFile } from './file';
 export declare class FolderScan {
     sourceOption: SourceOption;
     activeFile: BaseFile;
@@ -10,5 +10,5 @@ export declare class FolderScan {
     performScan(): FolderMeta;
     appendMeta(): void;
     shouldIgnore(filePath: string): any;
-    instantiateFileByType(filePath: any, sourceFile: any): PipeFile;
+    instantiateFileByType(filePath: any, sourceFile: any): ServiceFile;
 }

--- a/out/lib/models/health.d.ts
+++ b/out/lib/models/health.d.ts
@@ -1,0 +1,4 @@
+export interface Health {
+    missingDescription: boolean;
+    missingProperties?: boolean;
+}

--- a/out/lib/models/health.js
+++ b/out/lib/models/health.js
@@ -1,0 +1,2 @@
+"use strict";
+exports.__esModule = true;

--- a/out/lib/models/index.d.ts
+++ b/out/lib/models/index.d.ts
@@ -1,3 +1,4 @@
 export * from './property';
 export * from './options';
 export * from './comment';
+export * from './health';


### PR DESCRIPTION
This PR

- [x] Allows outputting of an object which describes the health of the file that is being examined 
- [x] Outputs this new health model so that all file-meta display this
- [x] Allow the health object to be easily extendable 